### PR TITLE
Enforce CSRF for cookie JWT auth and expand audit coverage

### DIFF
--- a/backend/inventory/api/auth.py
+++ b/backend/inventory/api/auth.py
@@ -26,6 +26,7 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
+from ..authentication import enforce_csrf
 from ..serializers import UserRegistrationSerializer
 from .throttles import LoginRateThrottle, LogoutRateThrottle, RegisterRateThrottle
 
@@ -471,6 +472,7 @@ class CustomTokenRefreshView(TokenRefreshView):
         # Prepare data for serializer
         data = request.data.copy()
         if 'refresh' not in data and refresh_cookie:
+            enforce_csrf(request)
             data['refresh'] = refresh_cookie
 
         # Extract remember preference

--- a/backend/inventory/authentication.py
+++ b/backend/inventory/authentication.py
@@ -7,10 +7,32 @@
 
 from __future__ import annotations                   # Enable forward references for type hints
 from django.conf import settings                     # Django settings configuration
-from rest_framework import authentication            # REST Framework authentication base classes
+from django.middleware.csrf import CsrfViewMiddleware
+from rest_framework import authentication, exceptions # REST Framework authentication base classes
 from rest_framework.request import Request           # REST Framework request object type
 from rest_framework_simplejwt.authentication import JWTAuthentication  # JWT authentication base class
 from rest_framework_simplejwt.exceptions import InvalidToken           # JWT validation error
+
+
+class _CSRFCheck(CsrfViewMiddleware):
+    """Return the CSRF failure reason instead of an HttpResponse."""
+
+    def _reject(self, request, reason):
+        return reason
+
+
+def enforce_csrf(request: Request) -> None:
+    """Apply Django's CSRF validation to cookie-authenticated API requests."""
+
+    def _get_response(_request):
+        return None
+
+    check = _CSRFCheck(_get_response)
+    check.process_request(request)
+    reason = check.process_view(request, None, (), {})
+    if reason:
+        raise exceptions.PermissionDenied(f'CSRF Failed: {reason}')
+
 
 class CookieJWTAuthentication(JWTAuthentication):
     """
@@ -70,6 +92,8 @@ class CookieJWTAuthentication(JWTAuthentication):
             # Token is invalid (expired, bad signature, etc.) - return None
             # This prevents authentication errors from breaking the request flow
             return None
+
+        enforce_csrf(request)
 
         # Token is valid - authenticate the user and return the result
         # get_user() loads the user from the database using the token's user_id claim

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -716,6 +716,7 @@ class ItemSerializer(serializers.ModelSerializer):
         
         user = self._require_user()
         tags = validated_data.pop('tags', None)
+        old_tag_ids = sorted(instance.tags.values_list('id', flat=True)) if tags is not None else None
         normalised = self._normalise_payload(validated_data)
 
         allowed_fields = {
@@ -738,7 +739,17 @@ class ItemSerializer(serializers.ModelSerializer):
         instance.save()
 
         if tags is not None:
-            instance.tags.set([tag for tag in tags if tag.user_id == user.id])
+            own_tags = [tag for tag in tags if tag.user_id == user.id]
+            instance.tags.set(own_tags)
+            new_tag_ids = sorted(instance.tags.values_list('id', flat=True))
+            if old_tag_ids != new_tag_ids:
+                ItemChangeLog.objects.create(
+                    item=instance,
+                    action='update',
+                    user=user,
+                    item_name=instance.name,
+                    changes={'tags': {'old': old_tag_ids, 'new': new_tag_ids}},
+                )
         return instance
 
 

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -912,6 +912,7 @@ class ItemChangeLogSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._location_cache: dict[int, str] = {}
+        self._tag_cache: dict[int, str] = {}
 
     def _resolve_location_name(self, value):
         if value in (None, ''):
@@ -933,15 +934,51 @@ class ItemChangeLogSerializer(serializers.ModelSerializer):
         self._location_cache[location_id] = name
         return name
 
+    def _resolve_tag_name(self, value):
+        if value in (None, ''):
+            return value
+        try:
+            tag_id = int(value)
+        except (TypeError, ValueError):
+            return value
+
+        if tag_id in self._tag_cache:
+            return self._tag_cache[tag_id]
+
+        tag = Tag.objects.filter(pk=tag_id).only('name').first()
+        if tag is None:
+            name = f"#{tag_id}"
+        else:
+            name = tag.name
+
+        self._tag_cache[tag_id] = name
+        return name
+
+    def _resolve_tag_names(self, value):
+        if value in (None, ''):
+            return value
+        if isinstance(value, (list, tuple, set)):
+            return [self._resolve_tag_name(tag_id) for tag_id in value]
+        return self._resolve_tag_name(value)
+
     def to_representation(self, instance):
         
         data = super().to_representation(instance)
         changes = data.get('changes')
         if isinstance(changes, dict):
+            changes = {
+                field: dict(change) if isinstance(change, dict) else change
+                for field, change in changes.items()
+            }
+            data['changes'] = changes
             location_change = changes.get('location_id')
             if isinstance(location_change, dict):
                 for key in ('old', 'new'):
                     location_change[key] = self._resolve_location_name(location_change.get(key))
+            tag_change = changes.get('tags')
+            if isinstance(tag_change, dict):
+                for key in ('old', 'new'):
+                    tag_change[key] = self._resolve_tag_names(tag_change.get(key))
         return data
 
     class Meta:

--- a/backend/inventory/signals.py
+++ b/backend/inventory/signals.py
@@ -138,6 +138,9 @@ AUDITED_FIELDS: tuple[str, ...] = (
     'purchase_date',     # Date item was purchased
     'value',             # Monetary value
     'location_id',       # Foreign key to Location (tracked by ID not object)
+    'wodis_inventory_number',
+    'employee_name',
+    'room_number',
 )
 
 # =========================

--- a/backend/inventory/tests/test_serializers.py
+++ b/backend/inventory/tests/test_serializers.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
-from ..models import Item, ItemList, Location, Tag
+from ..models import Item, ItemChangeLog, ItemList, Location, Tag
 from ..serializers import ItemListSerializer, ItemSerializer, UserRegistrationSerializer
 User = get_user_model()
 
@@ -119,6 +119,55 @@ class ItemSerializerTests(TestCase):
         updated_item = serializer.save()
         updated_item.refresh_from_db()
         self.assertIsNone(updated_item.wodis_inventory_number)
+
+    def test_update_audits_extended_item_fields(self):
+        item = Item.objects.create(name='Camera', owner=self.user, location
+            =self.location_user, wodis_inventory_number='OLD-1',
+            employee_name='Old Employee', room_number='100')
+        data = {'name': 'Camera', 'description': '', 'quantity': 1, 'value':
+            '', 'location': self.location_user.id, 'wodis_inventory_number':
+            'NEW-2', 'employee_name': 'New Employee', 'room_number': '200',
+            'tags': []}
+        serializer = self._get_serializer(instance=item, data=data, request
+            =self._build_request(self.user))
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated_item = serializer.save()
+
+        log = ItemChangeLog.objects.filter(item=updated_item, action='update'
+            ).latest('created_at')
+        self.assertEqual(log.changes['wodis_inventory_number']['old'],
+            'OLD-1')
+        self.assertEqual(log.changes['wodis_inventory_number']['new'],
+            'NEW-2')
+        self.assertEqual(log.changes['employee_name']['old'],
+            'Old Employee')
+        self.assertEqual(log.changes['employee_name']['new'],
+            'New Employee')
+        self.assertEqual(log.changes['room_number']['old'], '100')
+        self.assertEqual(log.changes['room_number']['new'], '200')
+
+    def test_update_audits_tag_changes(self):
+        item = Item.objects.create(name='Camera', owner=self.user, location
+            =self.location_user)
+        item.tags.set([self.tag_user])
+        data = {'name': 'Camera', 'description': '', 'quantity': 1, 'value':
+            '', 'location': self.location_user.id, 'tags': [self.
+            tag_user_2.id]}
+        serializer = self._get_serializer(instance=item, data=data, request
+            =self._build_request(self.user))
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated_item = serializer.save()
+
+        tag_logs = [
+            log for log in ItemChangeLog.objects.filter(item=updated_item,
+                action='update')
+            if 'tags' in log.changes
+        ]
+        self.assertEqual(len(tag_logs), 1)
+        self.assertEqual(tag_logs[0].changes['tags']['old'], [self.
+            tag_user.id])
+        self.assertEqual(tag_logs[0].changes['tags']['new'], [self.
+            tag_user_2.id])
 
 class ItemListSerializerTests(TestCase):
 

--- a/backend/inventory/tests/test_serializers.py
+++ b/backend/inventory/tests/test_serializers.py
@@ -3,7 +3,12 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from ..models import Item, ItemChangeLog, ItemList, Location, Tag
-from ..serializers import ItemListSerializer, ItemSerializer, UserRegistrationSerializer
+from ..serializers import (
+    ItemChangeLogSerializer,
+    ItemListSerializer,
+    ItemSerializer,
+    UserRegistrationSerializer,
+)
 User = get_user_model()
 
 class UserRegistrationSerializerTests(TestCase):
@@ -168,6 +173,36 @@ class ItemSerializerTests(TestCase):
             tag_user.id])
         self.assertEqual(tag_logs[0].changes['tags']['new'], [self.
             tag_user_2.id])
+
+    def test_change_log_serializer_resolves_tag_ids_to_names(self):
+        item = Item.objects.create(name='Camera', owner=self.user, location
+            =self.location_user)
+        missing_tag_id = self.tag_user_2.id + 1000
+        log = ItemChangeLog.objects.create(item=item, action='update', user
+            =self.user, item_name=item.name, changes={'tags': {'old': [
+            self.tag_user.id, missing_tag_id], 'new': [self.tag_user_2.id]}})
+
+        data = ItemChangeLogSerializer(log).data
+
+        self.assertEqual(data['changes']['tags']['old'], ['Electronics',
+            f'#{missing_tag_id}'])
+        self.assertEqual(data['changes']['tags']['new'], ['Appliances'])
+        log.refresh_from_db()
+        self.assertEqual(log.changes['tags']['old'], [self.tag_user.id,
+            missing_tag_id])
+
+    def test_change_log_serializer_still_resolves_location_ids(self):
+        item = Item.objects.create(name='Camera', owner=self.user, location
+            =self.location_user)
+        new_location = Location.objects.create(name='Office', user=self.user)
+        log = ItemChangeLog.objects.create(item=item, action='update', user
+            =self.user, item_name=item.name, changes={'location_id': {
+            'old': self.location_user.id, 'new': new_location.id}})
+
+        data = ItemChangeLogSerializer(log).data
+
+        self.assertEqual(data['changes']['location_id']['old'], 'Basement')
+        self.assertEqual(data['changes']['location_id']['new'], 'Office')
 
 class ItemListSerializerTests(TestCase):
 

--- a/backend/inventory/tests/test_views.py
+++ b/backend/inventory/tests/test_views.py
@@ -167,6 +167,35 @@ class LogoutViewTests(APITestCase):
         response = self.client.post(url, {'refresh': str(refresh)}, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_cookie_logout_without_csrf_is_rejected(self):
+
+        client = APIClient()
+        refresh = RefreshToken.for_user(self.user)
+        client.cookies[settings.JWT_ACCESS_COOKIE_NAME] = str(refresh.access_token)
+        client.cookies[settings.JWT_REFRESH_COOKIE_NAME] = str(refresh)
+        url = reverse('logout')
+
+        response = client.post(url, {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cookie_logout_with_csrf_succeeds_and_clears_cookies(self):
+
+        client = APIClient()
+        refresh = RefreshToken.for_user(self.user)
+        client.cookies[settings.JWT_ACCESS_COOKIE_NAME] = str(refresh.access_token)
+        client.cookies[settings.JWT_REFRESH_COOKIE_NAME] = str(refresh)
+        csrf_token = set_csrf_cookie(client)
+        url = reverse('logout')
+
+        response = client.post(url, {}, format='json', HTTP_X_CSRFTOKEN=csrf_token)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIn(settings.JWT_ACCESS_COOKIE_NAME, response.cookies)
+        self.assertIn(settings.JWT_REFRESH_COOKIE_NAME, response.cookies)
+        self.assertEqual(response.cookies[settings.JWT_ACCESS_COOKIE_NAME].value, '')
+        self.assertEqual(response.cookies[settings.JWT_REFRESH_COOKIE_NAME].value, '')
+
 class ItemViewSetTests(APITestCase):
 
     def setUp(self):

--- a/backend/inventory/tests/test_views.py
+++ b/backend/inventory/tests/test_views.py
@@ -28,6 +28,15 @@ from contextlib import contextmanager
 from ..models import Item, ItemImage, ItemList, Location, Tag, DuplicateQuarantine
 from ..views import ItemImageViewSet
 
+
+def set_csrf_cookie(client):
+
+    response = client.get(reverse('csrf_token'))
+    csrf_token = response.cookies[settings.CSRF_COOKIE_NAME].value
+    client.cookies[settings.CSRF_COOKIE_NAME] = csrf_token
+    return csrf_token
+
+
 class TimedAPITestCase(APITestCase):
 
     @contextmanager
@@ -45,7 +54,7 @@ class TimedAPITestCase(APITestCase):
 class BaseViewTestCase(TestCase):
 
     def setUp(self):
-        
+
         self.user = User.objects.create_user(username='testuser', password='password')
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
@@ -67,7 +76,7 @@ class LandingPageTests(TestCase):
 class TagViewSetTests(APITestCase):
 
     def setUp(self):
-        
+
         self.client = APIClient()
         self.user = User.objects.create_user('tagger', 'tagger@example.com', 'StrongPass123!')
         self.client.force_authenticate(user=self.user)
@@ -273,6 +282,97 @@ class ItemViewSetTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 0)
+
+class CookieJWTCSRFSecurityTests(APITestCase):
+
+    def setUp(self):
+
+        self.user = User.objects.create_user('csrf_user', 'csrf@example.com', 'StrongPass123!')
+        self.location = Location.objects.create(name='Storage', user=self.user)
+
+    def set_access_cookie(self, client):
+
+        refresh = RefreshToken.for_user(self.user)
+        client.cookies[settings.JWT_ACCESS_COOKIE_NAME] = str(refresh.access_token)
+        return refresh
+
+    def test_cookie_access_token_post_without_csrf_is_rejected(self):
+
+        client = APIClient()
+        self.set_access_cookie(client)
+        url = reverse('item-list')
+
+        response = client.post(url, {'name': 'Blocked', 'quantity': 1}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(Item.objects.filter(name='Blocked', owner=self.user).exists())
+
+    def test_cookie_access_token_get_without_csrf_succeeds(self):
+
+        client = APIClient()
+        self.set_access_cookie(client)
+        url = reverse('item-list')
+
+        response = client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_cookie_access_token_post_with_csrf_succeeds(self):
+
+        client = APIClient()
+        self.set_access_cookie(client)
+        csrf_token = set_csrf_cookie(client)
+        url = reverse('item-list')
+
+        response = client.post(
+            url,
+            {'name': 'Allowed', 'quantity': 1, 'location': self.location.id},
+            format='json',
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Item.objects.filter(name='Allowed', owner=self.user).exists())
+
+    def test_bearer_access_token_post_without_csrf_succeeds(self):
+
+        client = APIClient()
+        refresh = RefreshToken.for_user(self.user)
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {refresh.access_token}')
+        url = reverse('item-list')
+
+        response = client.post(
+            url,
+            {'name': 'Bearer Allowed', 'quantity': 1, 'location': self.location.id},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Item.objects.filter(name='Bearer Allowed', owner=self.user).exists())
+
+    def test_refresh_cookie_without_csrf_is_rejected(self):
+
+        client = APIClient()
+        refresh = RefreshToken.for_user(self.user)
+        client.cookies[settings.JWT_REFRESH_COOKIE_NAME] = str(refresh)
+        url = reverse('token_refresh')
+
+        response = client.post(url, {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_refresh_cookie_with_csrf_succeeds(self):
+
+        client = APIClient()
+        refresh = RefreshToken.for_user(self.user)
+        client.cookies[settings.JWT_REFRESH_COOKIE_NAME] = str(refresh)
+        csrf_token = set_csrf_cookie(client)
+        url = reverse('token_refresh')
+
+        response = client.post(url, {}, format='json', HTTP_X_CSRFTOKEN=csrf_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(settings.JWT_ACCESS_COOKIE_NAME, response.cookies)
 
 class ItemListViewSetTests(APITestCase):
 
@@ -591,7 +691,7 @@ class AuthSecurityTests(TimedAPITestCase):
             with self.assertTiming(min_seconds=0.1):
                 response = self.client.post(url, {'email': 'nobody@example.com', 'password': 'password'})
                 self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertIn('Login attempt with non-existent email', cm.output[0])
+        self.assertTrue(any('Authentication failed' in message for message in cm.output))
 
     def test_login_with_wrong_password_is_slowed(self):
         
@@ -606,7 +706,8 @@ class AuthSecurityTests(TimedAPITestCase):
         self.client.post(login_url, {'email': self.user.email, 'password': 'password123'})
 
         refresh_url = reverse('token_refresh')
-        response = self.client.post(refresh_url, {})
+        csrf_token = set_csrf_cookie(self.client)
+        response = self.client.post(refresh_url, {}, HTTP_X_CSRFTOKEN=csrf_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(settings.JWT_ACCESS_COOKIE_NAME, response.cookies)
         self.assertTrue(response.data['rotated'])

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -6,7 +6,7 @@
 import { create, type StateCreator } from 'zustand';              // State management library
 import { persist, type PersistOptions } from 'zustand/middleware'; // Persistence middleware
 
-import apiClient from '../api/client';                             // Configured API client
+import apiClient, { ensureCSRFToken } from '../api/client';         // Configured API client
 import type { LoginRequest, LoginResponse, RegisterRequest, UserProfile } from '../types/auth'; // Type definitions
 
 /**
@@ -41,7 +41,7 @@ interface AuthState {
   register: (payload: RegisterRequest) => Promise<void>;
   
   /** Refresh method - updates expired access token */
-  refreshAccessToken: () => Promise<void>;
+  refreshAccessToken: () => Promise<boolean>;
   
   /** Initialize method - restores auth state from storage */
   initialise: () => Promise<void>;
@@ -70,6 +70,9 @@ const resetState = (set: AuthStoreSetter) => {
 
 /** Type definition for Zustand persist middleware mutators */
 type PersistMutators = [['zustand/persist', unknown]];
+
+/** Persisted subset of authentication state. */
+type PersistedAuthState = Pick<AuthState, 'user' | 'isAuthenticated' | 'hasInitialised' | 'remembering'>;
 
 /**
  * Create authentication store with all state and actions.
@@ -191,6 +194,7 @@ const authStoreCreator: StateCreator<AuthState, PersistMutators> = (set, get) =>
     const payload = remember ? { remember: '1' } : undefined;
 
     try {
+      await ensureCSRFToken();
       const { data } = await apiClient.post<{ access_expires: number; rotated: boolean }>('/token/refresh/', payload);
       set({
         accessExpiresAt: Date.now() + data.access_expires * 1000,
@@ -242,7 +246,7 @@ const authStoreCreator: StateCreator<AuthState, PersistMutators> = (set, get) =>
  * Persists the authentication state to localStorage/sessionStorage
  * based on the user's "remember me" preference.
  */
-const persistOptions: PersistOptions<AuthState> = {
+const persistOptions: PersistOptions<AuthState, PersistedAuthState> = {
   name: AUTH_STORAGE_KEY,
   partialize: (state: AuthState) => ({
     user: state.user,
@@ -259,5 +263,5 @@ const persistOptions: PersistOptions<AuthState> = {
  * to create a fully functional authentication state store.
  */
 export const useAuthStore = create<AuthState>()(
-  persist<AuthState>(authStoreCreator, persistOptions),
+  persist<AuthState, [], [], PersistedAuthState>(authStoreCreator, persistOptions),
 );

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -225,6 +225,7 @@ const authStoreCreator: StateCreator<AuthState, PersistMutators> = (set, get) =>
    */
   logout: async () => {
     try {
+      await ensureCSRFToken();
       // Notify the backend to invalidate tokens
       await apiClient.post('/auth/logout/', {});
     } catch (error) {

--- a/nginx/emmatresor.conf
+++ b/nginx/emmatresor.conf
@@ -18,7 +18,7 @@ limit_req_zone $binary_remote_addr zone=emmatresor_static:10m rate=50r/s;  # Sta
 server {
     listen 80;                                            # Listen on HTTP port 80
     server_name _;                                          # Catch-all server name
-    client_max_body_size 0;
+    client_max_body_size 10m;
     charset utf-8;                                        # Use UTF-8 encoding for all responses
     
     root /usr/share/nginx/html;                               # Document root for frontend files

--- a/nginx/emmatresor_host.conf
+++ b/nginx/emmatresor_host.conf
@@ -14,7 +14,7 @@ limit_req_zone $binary_remote_addr zone=emmatresor_static:10m rate=50r/s;
 
 server {
     listen 80;
-    client_max_body_size 0;
+    client_max_body_size 10m;
     server_name emmatresor.example.com;
 
     set $csp_policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self'; frame-src 'none'; frame-ancestors 'self'; worker-src 'self'; child-src 'self'; manifest-src 'self'; media-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'";


### PR DESCRIPTION
## Summary
- Enforce server-side CSRF checks for JWT auth when requests use cookie-based credentials, while keeping bearer-token API clients unaffected.
- Expand item audit logging to include `wodis_inventory_number`, `employee_name`, `room_number`, and tag changes.
- Update auth and serializer tests to cover the new security and audit behavior.
- Limit Nginx request body size to `10m` in both deployment configs.

## Testing
- Added regression tests for CSRF enforcement on cookie-authenticated POST and refresh flows.
- Added audit tests for extended item fields and tag updates.
- Updated the auth timing test to match the current logging behavior.
- Validation run: Python syntax checks passed; repository diff checks passed. Full Django test suite was not run because Django is not installed in the current local Python environment.